### PR TITLE
Function arity rule to handle defprotocol

### DIFF
--- a/lib/dogma/rules/function_arity.ex
+++ b/lib/dogma/rules/function_arity.ex
@@ -16,17 +16,25 @@ defmodule Dogma.Rules.FunctionArity do
   end
 
   defp check_node({:def, _, _} = node, errors, max_arity) do
-    check_function(node, errors, max_arity)
+    check_def(node, errors, max_arity)
   end
   defp check_node({:defp, _, _} = node, errors, max_arity) do
-    check_function(node, errors, max_arity)
+    check_def(node, errors, max_arity)
   end
   defp check_node(node, errors, _max_arity) do
     {node, errors}
   end
 
-  defp check_function(node, errors, max_arity) do
-    {_, [line: line_number], [{_, _, function_args}, _]} = node
+  defp check_def(node, errors, max_arity) do
+    case node do
+      {_, [line: line_number], [{_, _, args}, _function_body]}
+        -> check_args(args, line_number, errors, max_arity)
+      {_, [line: line_number], [{_, _, args}]}
+        -> check_args(args, line_number, errors, max_arity)
+    end
+  end
+
+  defp check_args(function_args, line_number, errors, max_arity) do
     function_arity = Enum.count(function_args || [])
     if (function_arity > max_arity) do
       {node, [error(line_number, max_arity) | errors]}

--- a/test/dogma/rules/function_arity_test.exs
+++ b/test/dogma/rules/function_arity_test.exs
@@ -22,7 +22,22 @@ defmodule Dogma.Rules.FunctionArityTest do
       def point(a,b,c,d) do
       end
 
+      def has_defaults(a,b,c,d \\\\[]) do
+      end
+
       def point(a,b,c,{d, e, f}) do
+      end
+      """ |> test
+      %{ script: script }
+    end
+    should_register_no_errors
+  end
+
+  with "valid arity in a protocol definition" do
+    setup context do
+      script = """
+      defprotocol Some.Protocol do
+        def run(thing, context)
       end
       """ |> test
       %{ script: script }


### PR DESCRIPTION
a defprotocol will come up as a :def in the ast but won't match
{_, [line: line_number], [{_, _, args}, _function_body]} as the function body is missing.
This commit adds handling for this case
